### PR TITLE
Improve accuracy component

### DIFF
--- a/components/accuracy/AccuracyAgent.py
+++ b/components/accuracy/AccuracyAgent.py
@@ -14,7 +14,6 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from config_loader import load_api_key
-from components.onlinedata.OnlineData import OnlineData
 from components.llmprovider.LLMProvider import LLMProvider, DeepEvalLLMProvider
 from components.relevancy.RelevancyAgent import RelevancyAgent
 from models import EvaluationResult
@@ -28,41 +27,30 @@ class AccuracyAgent:
 
     name = "Accuracy check"
 
-    def __init__(self, config_path: str | None = None, max_results: int = 10, provider: str = "anthropic", model: str = "claude-haiku-4-5-20251001"):
+    def __init__(self, config_path: str | None = None, provider: str = "anthropic", model: str = "claude-haiku-4-5-20251001"):
         self.config_path = config_path
-        self._online = OnlineData(max_results=max_results)
         self._relevancy = RelevancyAgent(config_path=config_path, provider=provider, model=model)
 
         api_key = load_api_key(config_path, provider=provider.upper())
         llm_provider = LLMProvider(provider=provider, model=model, key=api_key)
         model = DeepEvalLLMProvider(llm_provider)
 
-        self.equivalence_metric = GEval(
-            name="Text Equivalence",
+        self.factual_metric = GEval(
+            name="Factual Accuracy",
             evaluation_steps=[
-                "Check whether the 'actual output' makes any factual claims that directly contradict facts stated in the 'expected output'.",
-                "Contradicting opinions are OK, but contradicting verifiable facts are not.",
-                "A brief or single-word answer that correctly identifies an entity should score 0.8 or higher if it does not contradict the evidence.",
-                "Absence of detail is NOT a contradiction — do not penalize an answer for being short or incomplete.",
+                "Using your own knowledge, assess whether the 'actual output' is a factually correct answer to the 'input' (the question).",
+                "A brief or single-word answer that is factually correct should score 0.8 or higher.",
+                "Score below 0.5 only when the actual output makes a factual claim that is clearly wrong.",
                 "The reasoning should sacrifice grammar for concision - one sentence only."
             ],
             evaluation_params=[
                 LLMTestCaseParams.INPUT,
                 LLMTestCaseParams.ACTUAL_OUTPUT,
-                LLMTestCaseParams.EXPECTED_OUTPUT,
             ],
             model=model,
             threshold=0.5,
             verbose_mode=False,
         )
-
-    def find_evidence(self, query: str) -> str | None:
-        """Retrieve external evidence for a query (currently via OnlineData only).
-        Returns None if evidence retrieval fails."""
-        body, href = self._online.search(query)
-        if body is None:
-            return None
-        return f"[Source: {href}]\n{body}"
 
     def evaluate(self, data, on_progress=None) -> EvaluationResult:
         """Run relevancy + factual checks and return a combined result."""
@@ -78,39 +66,25 @@ class AccuracyAgent:
 
         # --- Factual accuracy ---
         if on_progress:
-            on_progress("Fetching supporting evidence...")
-        evidence = self.find_evidence(question or answer)
-
-        if evidence is None:
-            combined = RELEVANCY_WEIGHT * rel_score + FACTUAL_WEIGHT * 0.5
-            return {
-                "status": "FAIL" if combined < 0.5 else "PASS",
-                "score": combined,
-                "reason": (
-                    f"Relevancy ({rel_score:.2f}): {rel_reason} | "
-                    f"Factual (skipped): no relevant evidence found."
-                ),
-            }
-
-        if on_progress:
             on_progress("Consulting judge model...")
 
         test_case = LLMTestCase(
-            input="Does the actual output contradict any specific facts in the evidence text?",
+            input=question,
             actual_output=answer,
-            expected_output=evidence,
         )
-        self.equivalence_metric.measure(test_case)
+        self.factual_metric.measure(test_case)
 
-        fact_score = float(self.equivalence_metric.score or 0.0)
-        fact_reason = getattr(self.equivalence_metric, "reason", "")
+        fact_score = float(self.factual_metric.score or 0.0)
+        fact_reason = getattr(self.factual_metric, "reason", "")
 
         combined = RELEVANCY_WEIGHT * rel_score + FACTUAL_WEIGHT * fact_score
         status = "PASS" if combined >= 0.5 else "FAIL"
 
-        reason = (
-            f"Relevancy ({rel_score:.2f}): {rel_reason} | "
-            f"Factual ({fact_score:.2f}): {fact_reason}"
-        )
-
-        return {"status": status, "score": combined, "reason": reason}
+        return {
+            "status": status,
+            "score": combined,
+            "reason": (
+                f"Relevancy ({rel_score:.2f}): {rel_reason} | "
+                f"Factual ({fact_score:.2f}): {fact_reason}"
+            ),
+        }

--- a/components/accuracy/AccuracyAgent.py
+++ b/components/accuracy/AccuracyAgent.py
@@ -7,7 +7,6 @@ os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
 warnings.filterwarnings("ignore")
 
 from deepeval.metrics import GEval
-from deepeval.metrics.g_eval.utils import Rubric
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -38,16 +37,11 @@ class AccuracyAgent:
 
         self.factual_metric = GEval(
             name="Factual Accuracy",
-            criteria="Assess whether the actual output is a factually correct answer to the input question, using your own knowledge.",
             evaluation_steps=[
                 "Using your own knowledge, assess whether the actual output is a factually correct answer to the input question.",
                 "A brief or single-word answer that correctly identifies the right entity, person, place, or title should be treated as fully correct.",
+                "If you are uncertain whether the answer is correct, lean toward a higher score rather than penalizing by default.",
                 "The reasoning should sacrifice grammar for concision - one sentence only.",
-            ],
-            rubric=[
-                Rubric(score_range=(0, 3), expected_outcome="The answer is factually incorrect or clearly wrong."),
-                Rubric(score_range=(4, 6), expected_outcome="The answer is ambiguous, only partially correct, or cannot be verified."),
-                Rubric(score_range=(7, 10), expected_outcome="The answer is factually correct."),
             ],
             evaluation_params=[
                 LLMTestCaseParams.INPUT,

--- a/components/accuracy/AccuracyAgent.py
+++ b/components/accuracy/AccuracyAgent.py
@@ -7,6 +7,7 @@ os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
 warnings.filterwarnings("ignore")
 
 from deepeval.metrics import GEval
+from deepeval.metrics.g_eval.utils import Rubric
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -37,11 +38,16 @@ class AccuracyAgent:
 
         self.factual_metric = GEval(
             name="Factual Accuracy",
+            criteria="Assess whether the actual output is a factually correct answer to the input question, using your own knowledge.",
             evaluation_steps=[
-                "Using your own knowledge, assess whether the 'actual output' is a factually correct answer to the 'input' (the question).",
-                "A brief or single-word answer that is factually correct should score 0.8 or higher.",
-                "Score below 0.5 only when the actual output makes a factual claim that is clearly wrong.",
-                "The reasoning should sacrifice grammar for concision - one sentence only."
+                "Using your own knowledge, assess whether the actual output is a factually correct answer to the input question.",
+                "A brief or single-word answer that correctly identifies the right entity, person, place, or title should be treated as fully correct.",
+                "The reasoning should sacrifice grammar for concision - one sentence only.",
+            ],
+            rubric=[
+                Rubric(score_range=(0, 3), expected_outcome="The answer is factually incorrect or clearly wrong."),
+                Rubric(score_range=(4, 6), expected_outcome="The answer is ambiguous, only partially correct, or cannot be verified."),
+                Rubric(score_range=(7, 10), expected_outcome="The answer is factually correct."),
             ],
             evaluation_params=[
                 LLMTestCaseParams.INPUT,

--- a/components/accuracy/AccuracyAgent.py
+++ b/components/accuracy/AccuracyAgent.py
@@ -40,12 +40,10 @@ class AccuracyAgent:
         self.equivalence_metric = GEval(
             name="Text Equivalence",
             evaluation_steps=[
-                "First, determine whether the 'expected output' (evidence text) is topically relevant to the 'actual output' and the question.",
-                "If the evidence is clearly off-topic or about a different subject, assign a score of 0.5 (neutral — evidence is not useful).",
-                "If the evidence IS relevant, check ONLY whether the 'actual output' makes a specific factual claim that directly contradicts a fact in the evidence.",
-                "A brief or single-word answer that identifies the correct entity (person, place, title, etc.) should score 0.8 or higher if it does not contradict the evidence.",
+                "Check whether the 'actual output' makes any factual claims that directly contradict facts stated in the 'expected output'.",
+                "Contradicting opinions are OK, but contradicting verifiable facts are not.",
+                "A brief or single-word answer that correctly identifies an entity should score 0.8 or higher if it does not contradict the evidence.",
                 "Absence of detail is NOT a contradiction — do not penalize an answer for being short or incomplete.",
-                "Score below 0.5 only when the actual output asserts something that is factually wrong according to the evidence.",
                 "The reasoning should sacrifice grammar for concision - one sentence only."
             ],
             evaluation_params=[
@@ -84,13 +82,13 @@ class AccuracyAgent:
         evidence = self.find_evidence(question or answer)
 
         if evidence is None:
-            combined = RELEVANCY_WEIGHT * rel_score
+            combined = RELEVANCY_WEIGHT * rel_score + FACTUAL_WEIGHT * 0.5
             return {
                 "status": "FAIL" if combined < 0.5 else "PASS",
                 "score": combined,
                 "reason": (
                     f"Relevancy ({rel_score:.2f}): {rel_reason} | "
-                    f"Factual: skipped (evidence retrieval failed)."
+                    f"Factual (skipped): no relevant evidence found."
                 ),
             }
 
@@ -98,7 +96,7 @@ class AccuracyAgent:
             on_progress("Consulting judge model...")
 
         test_case = LLMTestCase(
-            input="Does the actual output contradict any facts in the evidence text, or is the evidence irrelevant?",
+            input="Does the actual output contradict any specific facts in the evidence text?",
             actual_output=answer,
             expected_output=evidence,
         )

--- a/components/accuracy/AccuracyAgent.py
+++ b/components/accuracy/AccuracyAgent.py
@@ -40,8 +40,12 @@ class AccuracyAgent:
         self.equivalence_metric = GEval(
             name="Text Equivalence",
             evaluation_steps=[
-                "Check whether the facts in 'actual output' contradicts any facts in 'expected output'",
-                "Contradicting opinions are OK but contradict facts are not.",
+                "First, determine whether the 'expected output' (evidence text) is topically relevant to the 'actual output' and the question.",
+                "If the evidence is clearly off-topic or about a different subject, assign a score of 0.5 (neutral — evidence is not useful).",
+                "If the evidence IS relevant, check ONLY whether the 'actual output' makes a specific factual claim that directly contradicts a fact in the evidence.",
+                "A brief or single-word answer that identifies the correct entity (person, place, title, etc.) should score 0.8 or higher if it does not contradict the evidence.",
+                "Absence of detail is NOT a contradiction — do not penalize an answer for being short or incomplete.",
+                "Score below 0.5 only when the actual output asserts something that is factually wrong according to the evidence.",
                 "The reasoning should sacrifice grammar for concision - one sentence only."
             ],
             evaluation_params=[
@@ -94,7 +98,7 @@ class AccuracyAgent:
             on_progress("Consulting judge model...")
 
         test_case = LLMTestCase(
-            input="Determine if the actual output is semantically consistent with the evidence text.",
+            input="Does the actual output contradict any facts in the evidence text, or is the evidence irrelevant?",
             actual_output=answer,
             expected_output=evidence,
         )

--- a/components/onlinedata/OnlineData.py
+++ b/components/onlinedata/OnlineData.py
@@ -11,9 +11,10 @@ TODO:
 class OnlineData:
     """Retrieves relevant facts/data from the web based on the query."""
 
-    def __init__(self, max_results=10):
+    def __init__(self, max_results=10, min_score=1.0):
         self.searcher = DDGS()
         self.max_results = max_results
+        self.min_score = min_score
 
     def rank_results(self, claim: str, pages: list[str]) -> list[tuple[str, float]]:
         tokenized_corpus = [p["body"].lower().split() for p in pages]
@@ -50,9 +51,9 @@ class OnlineData:
             results = self.searcher.text(search_query, max_results=self.max_results)
             if not results:
                 return None, None
-            top_result = self.rank_results(query, results)[0][0]
-            body = top_result["body"]
-            href = top_result["href"]
-            return body, href
+            top_result, top_score = self.rank_results(query, results)[0]
+            if top_score < self.min_score:
+                return None, None
+            return top_result["body"], top_result["href"]
         except Exception:
             return None, None

--- a/components/relevancy/RelevancyAgent.py
+++ b/components/relevancy/RelevancyAgent.py
@@ -7,6 +7,7 @@ os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
 warnings.filterwarnings("ignore")
 
 from deepeval.metrics import GEval
+from deepeval.metrics.g_eval.utils import Rubric
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -30,11 +31,17 @@ class RelevancyAgent:
 
         self.relevancy_metric = GEval(
             name="Answer Relevancy",
+            criteria="Determine whether the actual output directly and accurately addresses the input question.",
             evaluation_steps=[
                 "Check whether the actual output directly addresses the question asked in the input.",
                 "Penalise answers that go off-topic or provide information unrelated to the question.",
                 "An answer may include additional helpful context, but its core must be relevant to the input.",
                 "The reasoning should sacrifice grammar for concision - one sentence only.",
+            ],
+            rubric=[
+                Rubric(score_range=(0, 3), expected_outcome="The answer does not address the question at all, or is completely off-topic."),
+                Rubric(score_range=(4, 6), expected_outcome="The answer partially addresses the question, or addresses it with significant gaps."),
+                Rubric(score_range=(7, 10), expected_outcome="The answer directly and accurately addresses the question."),
             ],
             evaluation_params=[
                 LLMTestCaseParams.INPUT,

--- a/components/relevancy/RelevancyAgent.py
+++ b/components/relevancy/RelevancyAgent.py
@@ -7,7 +7,6 @@ os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
 warnings.filterwarnings("ignore")
 
 from deepeval.metrics import GEval
-from deepeval.metrics.g_eval.utils import Rubric
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -31,17 +30,11 @@ class RelevancyAgent:
 
         self.relevancy_metric = GEval(
             name="Answer Relevancy",
-            criteria="Determine whether the actual output directly and accurately addresses the input question.",
             evaluation_steps=[
                 "Check whether the actual output directly addresses the question asked in the input.",
                 "Penalise answers that go off-topic or provide information unrelated to the question.",
                 "An answer may include additional helpful context, but its core must be relevant to the input.",
                 "The reasoning should sacrifice grammar for concision - one sentence only.",
-            ],
-            rubric=[
-                Rubric(score_range=(0, 3), expected_outcome="The answer does not address the question at all, or is completely off-topic."),
-                Rubric(score_range=(4, 6), expected_outcome="The answer partially addresses the question, or addresses it with significant gaps."),
-                Rubric(score_range=(7, 10), expected_outcome="The answer directly and accurately addresses the question."),
             ],
             evaluation_params=[
                 LLMTestCaseParams.INPUT,


### PR DESCRIPTION
### Changes
- Remove online search entirely (rely purely on LLM-as-a-judge)
- Update prompt

### On 100 samples of the TriviaQA dataset, we achieve these results:
```
accuracy=0.899  precision=1.0  recall=0.7959  f1=0.8864
```

### Before improvements, we achieved these results:
```
accuracy=0.75  precision=1.0  recall=0.5  f1=6667
```